### PR TITLE
:zap: Remove AH1 dependency to allow use with other skins

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="screensaver.arctic.mirage" name="Arctic Mirage" version="1.7" provider-name="drinfernoo">
+<addon id="screensaver.arctic.mirage" name="Arctic Mirage" version="1.8" provider-name="drinfernoo">
     <extension point="xbmc.ui.screensaver" library="default.py"/>
     <extension point="xbmc.python.script" library="script.py"/>
     <extension point="xbmc.addon.metadata">

--- a/addon.xml
+++ b/addon.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="screensaver.arctic.mirage" name="Arctic Mirage" version="1.7" provider-name="drinfernoo">
-    <requires>
-        <import addon="skin.arctic.horizon" version="0.1.8"/>
-    </requires>
-    
     <extension point="xbmc.ui.screensaver" library="default.py"/>
     <extension point="xbmc.python.script" library="script.py"/>
-    
     <extension point="xbmc.addon.metadata">
         <summary lang="en">Arctic Mirage</summary>
         <description lang="en">An Arctic-styled screensaver.</description>


### PR DESCRIPTION
Like the title says -- remove the AH1 dependency to allow installing for other skins (e.g. AH2) without forcing AH1 to be installed.